### PR TITLE
Added the ability to use a proxy object to store properties to a file

### DIFF
--- a/FileBackedStorage.js
+++ b/FileBackedStorage.js
@@ -1,0 +1,79 @@
+/* Use json files as plain objects
+ * Usage example:
+ (async () => {
+     var zeroframe = new ZeroFrame()
+     var zeropage = new ZeroPage(zeroframe)
+     var zerofs = new ZeroFS(zeropage)
+     var storage = FileBackedStorage(zerofs, "data/users/" + zeroframe.site_info.auth_address + "/data.json")
+     if (await storage.$exists)
+         await storage.$load
+     storage["a"] = 3
+     await storage.$save$sign$publish
+     storage["a"] = 5
+     await storage.$load
+     // Now storage["a"] == 3.
+ })()
+ */
+
+const FileBackedStorage = (zerofs, filename) => {
+    var handler = {
+	get: (inner, key) => {
+	    // If key is without $ we return its property
+	    let expanded = key.split("$")
+	    if (expanded.length == 1)
+		return inner[key]
+	    else {
+		// Otherwise we return a promise for the action
+		let promise = new Promise(res => res())
+		for (let method of expanded) {
+		    switch (method) {
+		    case "":
+			break
+		    case "delete":
+			promise = promise.then(() => zerofs.deleteFile(filename))
+			break
+		    case "exists":
+			promise = promise.then(() => zerofs.fileExists(filename))
+			break
+		    case "load":
+			promise = promise
+			    .then(() => zerofs.readFile(filename))
+			    .then(content => inner = JSON.parse(content))
+			break
+		    case "save":
+			promise = promise.then(() => zerofs.writeFile(filename, JSON.stringify(inner)))
+			break
+		    case "sign":
+			promise = promise.then(() => zerofs.page.sign(filename))
+			break
+		    case "publish":
+			promise = promise.then(() => zerofs.page.publish(filename))
+			break
+		    default:
+			throw "Unknown method " + method
+		    }
+		}
+		return promise
+	    }
+	},
+	set: (inner, key, value) => {
+	    let expanded = key.split("$")
+	    if (expanded.length == 1)
+		return inner[key] = value
+	    else
+		throw key + " is not settable!"
+	}
+    }
+    return new Proxy({}, handler)
+}
+
+const FolderBackedStorage = (zerofs, folderpath) => {
+    var handler = {
+	get: (inner, key) => {
+	    if (inner[key] == undefined)
+		inner[key] = FileBackedStorage(folderpath + "/" + key + ".json")
+	    return inner[key]
+	}
+    }
+    return new Proxy({}, handler)
+}


### PR DESCRIPTION
We talked about this in [a ZeroTalk thread](http://127.0.0.1:43110/Talk.ZeroNetwork.bit/?Topic:1535667676_14mSHL2TBcqcLNcfpmg5jyGVS9RZia3FiX)

A simple usage example:
```javascript
 (async () => {
     var zeroframe = new ZeroFrame()
     var zeropage = new ZeroPage(zeroframe)
     var zerofs = new ZeroFS(zeropage)
     var storage = FileBackedStorage(zerofs, "data/users/" + zeroframe.site_info.auth_address + "/data.json")
     if (await storage.$exists)
         await storage.$load
     storage["a"] = 3
     await storage.$save$sign$publish
     storage["a"] = 5
     await storage.$load
     // Now storage["a"] == 3.
})()
```